### PR TITLE
Fix image type

### DIFF
--- a/src/types.zig
+++ b/src/types.zig
@@ -31,26 +31,8 @@ pub const Format = enum {
     text,
 };
 
-pub const Image = struct {
-    value: union(enum) {
-        path: []const u8,
-        bytes: []const u8,
-        base64: []const u8,
-    },
-
-    pub fn fromPath(path: []const u8) !Image {
-        const file = try std.fs.openFileAbsolute(path, .{});
-        defer file.close();
-
-        const contents = try file.readToEndAlloc(std.heap.page_allocator, std.math.maxInt(usize));
-        defer std.heap.page_allocator.free(contents);
-
-        var encoded: [base64.Base64Encoder.calcSize(contents.len)]u8 = undefined;
-        _ = base64.standard.Encoder.encode(&encoded, contents);
-
-        return Image{ .value = .{ .base64 = try std.heap.page_allocator.dupe(u8, &encoded) } };
-    }
-};
+// Base64 encoded images
+pub const Image = []const u8;
 
 pub const Options = struct {
     // Load time options


### PR DESCRIPTION
When using images, we get the following error:
```
Response: {"error":"json: cannot unmarshal object into Go struct field GenerateRequest.images of type api.ImageData"}
Error: json: cannot unmarshal object into Go struct field GenerateRequest.images of type api.ImageData
```

While looking at the documentation, it states:
https://github.com/ollama/ollama/blob/09d308d6b6c7995e3fb565e0ecfa184d49205f00/docs/api.md?plain=1#L45

This PR fixes the incompatibility.